### PR TITLE
Give mouse tooltips unique paths

### DIFF
--- a/Road Precision/Systems/PrecisionNetCourseTooltipSystem.cs
+++ b/Road Precision/Systems/PrecisionNetCourseTooltipSystem.cs
@@ -63,12 +63,14 @@ namespace Road_Precision.Systems
             // Create standard string tooltips (UI recognizes these)
             m_Length = new StringTooltip
             {
+                path = "precisionNetCourse/length",
                 icon = "Media/Glyphs/Length.svg",
                 value = "0m"
             };
 
             m_Slope = new StringTooltip
             {
+                path = "precisionNetCourse/slope",
                 icon = "Media/Glyphs/Slope.svg",
                 value = "0%"
             };


### PR DESCRIPTION
`AddMouseTooltip` throws when two tooltips share the same path segment. The precision length and slope tooltips both defaulted to path. Assign explicit, distinct paths so the mouse tooltips no longer collide.

Fixes #8 